### PR TITLE
Change SSH daemon config file to local name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SSH Config Language
 
-Provides some simple settings and snippets for `sshd_config` files.
+Provides some simple settings and snippets for `~/.ssh/config` files.
 
 ## Installation
 


### PR DESCRIPTION
`sshd_config` is usually a server file at `/etc/ssh/sshd_config`. After reading the source for the snippet, I think you actually meant the one for a workstation's home directory at `~/.ssh/config`.
