### PR TITLE
Fix highlight when line ends with a hash sign

### DIFF
--- a/SSH Config.tmLanguage
+++ b/SSH Config.tmLanguage
@@ -29,7 +29,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>^\s*[;#].+</string>
+			<string>^\s*[;#].*</string>
 			<key>name</key>
 			<string>comment</string>
 		</dict>


### PR DESCRIPTION
Not exactly SSH-relevant, but here is a screenshot of a Samba config file:

![smb.conf](http://i.imgur.com/oRzkgmO.png)