### PR TITLE
Mark `ssh-rsa` as deprecated

### DIFF
--- a/Authorized Keys.sublime-syntax
+++ b/Authorized Keys.sublime-syntax
@@ -18,7 +18,7 @@ contexts:
         - meta_scope: meta.line.authorized-key.authorized_keys
         - include: SSH Common.sublime-syntax#pop-before-nl
         - include: SSH Common.sublime-syntax#pop-nl
-        - include: SSH Common.sublime-syntax#ssh-algorithms
+        - include: SSH Common.sublime-syntax#ssh-key-types
         - include: SSH Common.sublime-syntax#ssh-fingerprint-with-label
         - include: flag-options
         - include: value-options

--- a/Known Hosts.sublime-syntax
+++ b/Known Hosts.sublime-syntax
@@ -24,7 +24,7 @@ contexts:
         - match: ','
           scope: punctuation.separator.sequence.known_hosts
         - include: SSH Common.sublime-syntax#ssh-fingerprint-with-label
-        - include: SSH Common.sublime-syntax#ssh-algorithms
+        - include: SSH Common.sublime-syntax#ssh-key-types
         - include: hostname-or-ip-value
 
   hostname-or-ip-value:

--- a/SSH Common.sublime-syntax
+++ b/SSH Common.sublime-syntax
@@ -70,33 +70,88 @@ contexts:
             1: meta.annotation.identifier.ssh.common string.unquoted.ssh.common
           pop: true
 
-  ssh-algorithms:
+  ssh-key-types:
+    # ssh -Q key
     - match: |-
         \b(?x:
-          (?:sk-)?
-          (?:ssh-(?:rsa|dss|ed25519)|
+          (?:ssh-(?:dss))
+        )(?:(?:-cert-v01)?(@)openssh\.com)?\b
+      scope: invalid.deprecated.key-type.ssh.common
+      captures:
+        1: punctuation.separator.sequence.ssh.common
+    - match: |-
+        \b(?x:
+          (?:
+            ssh-rsa|   # Deprecation notice https://www.openssh.com/txt/release-8.2
+            (?:sk-)?ssh-ed25519|
+            (?:ed25519|ecdsa)-sk|
             rsa-sha2-(?:256|512)|
-            ecdsa-sha2-nistp(?:256|384|521)
+            (?:sk-)?ecdsa-sha2-nistp(?:256|384|521)
           )
-        )(?:(?:-cert-v01)?@openssh\.com)?\b
-      scope: support.function.algorithm.ssh.common
+        )(?:(?:-cert-v01)?(@)openssh\.com)?\b
+      scope: support.type.key-type.ssh.common
+      captures:
+        1: punctuation.separator.sequence.ssh.common
 
   ssh-ciphers:
-    - match: |-
-        \b(?x:
-          aes(?:128|192|256)-ctr|
-          aes(?:128|256)-gcm@openssh\.com|
-          chacha20-poly1305@openssh\.com
-        )\b
-      scope: support.function.cipher.ssh.common
+    # ssh -Q ciphers
     - match: |-
         \b(?x:
           aes(?:128|192|256)-cbc|
           (?:blowfish|cast128|3des)-cbc|
-          rijndael-cbc@lysator\.liu\.se|
+          rijndael-cbc(@)lysator\.liu\.se|
           arcfour(?:128|265)?
         )\b
       scope: invalid.deprecated.cipher.ssh.common
+      captures:
+        1: punctuation.separator.sequence.ssh.common
+    - match: |-
+        \b(?x:
+          aes(?:128|192|256)-ctr|
+          aes(?:128|256)-gcm(@)openssh\.com|
+          chacha20-poly1305(@)openssh\.com
+        )\b
+      scope: support.function.cipher.ssh.common
+      captures:
+        1: punctuation.separator.sequence.ssh.common
+        2: punctuation.separator.sequence.ssh.common
+
+  ssh-kex-algorithms:
+    # ssh -Q kex
+    - match: |-
+        \b(?x:
+          diffie-hellman-group(?:14?|-exchange)-sha1
+        )\b
+      scope: invalid.deprecated.kex-algorithm.ssh.common
+    - match: |-
+        \b(?x:
+          diffie-hellman-group(?:1[468]|-exchange)-sha(?:256|512)
+          |ecdh-sha2-nist(?:256|384|512)
+          |curve25519-sha256(?:(@)libssh\.org)?
+        )\b
+      scope: support.function.kex-algorithm.ssh.common
+      captures:
+        1: punctuation.separator.sequence.ssh.common
+
+  ssh-MACs:
+    # ssh -Q mac
+    - match: |-
+        \b(?x:
+          hmac-ripemd160
+          |hmac-md5(?:-96)?
+        )(?:(?:-etm)?(@)openssh\.com)?\b
+      scope: invalid.deprecated.mac-algorithm.ssh.common
+      captures:
+        1: punctuation.separator.sequence.ssh.common
+    - match: |-
+        \b(?x:
+          hmac-sha1(?:-96)?
+          |hmac-sha2-(?:256|512)
+          |umac-(?:64|128)
+        )(?:(?:-etm)?(@)openssh\.com)?\b
+      scope: support.function.mac-algorithm.ssh.common
+      captures:
+        1: punctuation.separator.sequence.ssh.common
 
   mac-addresses:
     - match: (?:[0-9a-fA-F]{2}:){5}(?:[0-9a-fA-F]{2})

--- a/SSH Common.sublime-syntax
+++ b/SSH Common.sublime-syntax
@@ -74,7 +74,7 @@ contexts:
     # ssh -Q key
     - match: |-
         \b(?x:
-          (?:ssh-(?:dss))
+          (?:ssh-(?:dss|rsa))
         )(?:(?:-cert-v01)?(@)openssh\.com)?\b
       scope: invalid.deprecated.key-type.ssh.common
       captures:
@@ -82,7 +82,6 @@ contexts:
     - match: |-
         \b(?x:
           (?:
-            ssh-rsa|   # Deprecation notice https://www.openssh.com/txt/release-8.2
             (?:sk-)?ssh-ed25519|
             (?:ed25519|ecdsa)-sk|
             rsa-sha2-(?:256|512)|

--- a/SSH Config.sublime-syntax
+++ b/SSH Config.sublime-syntax
@@ -281,8 +281,10 @@ contexts:
       scope: keyword.operator.logical.ssh_config
     - match: ','
       scope: punctuation.separator.sequence.ssh_config
-    - include: SSH Common.sublime-syntax#ssh-algorithms
+    - include: SSH Common.sublime-syntax#ssh-key-types
     - include: SSH Common.sublime-syntax#ssh-ciphers
+    - include: SSH Common.sublime-syntax#ssh-kex-algorithms
+    - include: SSH Common.sublime-syntax#ssh-MACs
     - include: SSH Common.sublime-syntax#ipv6-square-bracket
     - include: SSH Common.sublime-syntax#ip-addresses-with-cidr
 

--- a/SSHD Config.sublime-syntax
+++ b/SSHD Config.sublime-syntax
@@ -135,8 +135,10 @@ contexts:
       scope: constant.language.set.sshd_config
     - match: \b(?i:default)\b
       scope: constant.language.default.sshd_config
-    - include: SSH Common.sublime-syntax#ssh-algorithms
+    - include: SSH Common.sublime-syntax#ssh-key-types
     - include: SSH Common.sublime-syntax#ssh-ciphers
+    - include: SSH Common.sublime-syntax#ssh-kex-algorithms
+    - include: SSH Common.sublime-syntax#ssh-MACs
     - include: SSH Common.sublime-syntax#ipv6-square-bracket
     - include: SSH Common.sublime-syntax#ip-addresses-with-cidr
     - include: tokens

--- a/Tests/syntax_test.authorized_keys
+++ b/Tests/syntax_test.authorized_keys
@@ -6,7 +6,7 @@
 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHeDxE1jPGCLo51RSF7CeJbp4raIc3xo6TBiqkz4WRWI you@example.com
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.line.authorized-key
 #                                                                                               ^ - meta.line.authorized-key
-# ^^^^^^^^^ support.function.algorithm
+# ^^^^^^^^^ support.type.key-type
 #           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ variable.other.fingerprint
 #                                                                                ^^^^^^^^^^^^^^^ meta.annotation.identifier string.unquoted
 
@@ -31,7 +31,7 @@ expiry-time="20190606" ssh-rsa AAAAB3N21S== user@example.net
 #            ^^^^^^^^ constant
 #           ^^^^^^^^^^ string.quoted.double
 #                    ^ punctuation.definition.string.end
-#                      ^^^^^^^ support.function.algorithm
+#                      ^^^^^^^ support.type.key-type
 environment="NAME=value",environment="NAME2=value2" ssh-rsa AAAAB3N21S==
 # ^^^^^^^^^ keyword.other
 #          ^ keyword.operator.assignment

--- a/Tests/syntax_test.authorized_keys
+++ b/Tests/syntax_test.authorized_keys
@@ -31,7 +31,7 @@ expiry-time="20190606" ssh-rsa AAAAB3N21S== user@example.net
 #            ^^^^^^^^ constant
 #           ^^^^^^^^^^ string.quoted.double
 #                    ^ punctuation.definition.string.end
-#                      ^^^^^^^ support.type.key-type
+#                      ^^^^^^^ invalid.deprecated
 environment="NAME=value",environment="NAME2=value2" ssh-rsa AAAAB3N21S==
 # ^^^^^^^^^ keyword.other
 #          ^ keyword.operator.assignment

--- a/Tests/syntax_test.known_hosts
+++ b/Tests/syntax_test.known_hosts
@@ -8,7 +8,7 @@ github.com,192.30.252.129 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9
 # ^^^^^^^^ meta.string.host string.unquoted
 #         ^ punctuation.separator.sequence
 #          ^^^^^^^^^^^^^^ constant.numeric.ip-address.v4
-#                         ^^^^^^^ support.function.algorithm
+#                         ^^^^^^^ support.type.key-type
 #                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.line.known-host variable.other.fingerprint
 #                                                                                                                                                                                                                                                                                                                                                                                                                     ^ - meta
 

--- a/Tests/syntax_test.known_hosts
+++ b/Tests/syntax_test.known_hosts
@@ -8,7 +8,7 @@ github.com,192.30.252.129 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9
 # ^^^^^^^^ meta.string.host string.unquoted
 #         ^ punctuation.separator.sequence
 #          ^^^^^^^^^^^^^^ constant.numeric.ip-address.v4
-#                         ^^^^^^^ support.type.key-type
+#                         ^^^^^^^ invalid.deprecated
 #                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.line.known-host variable.other.fingerprint
 #                                                                                                                                                                                                                                                                                                                                                                                                                     ^ - meta
 


### PR DESCRIPTION
As per OpenSSH 8.2 https://www.openssh.com/releasenotes.html#8.2 `ssh-rsa` will be marked as deprecated. Questions, comments or concerns?