### PR TITLE
Fix recursion sanity limit

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -18,8 +18,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - build: 4180
+          - build: 4183
             packages: master
+          - build: 4180
+            packages: v4180
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -18,9 +18,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - build: 3211
-            packages: st3
-          - build: 4090
+          - build: 4180
             packages: master
     runs-on: ubuntu-latest
     steps:

--- a/Embedded Bash.sublime-syntax
+++ b/Embedded Bash.sublime-syntax
@@ -1,0 +1,38 @@
+%YAML 1.2
+---
+# See http://www.sublimetext.com/docs/3/syntax.html
+scope: source.shell.bash.ssh_config
+version: 2
+hidden: true
+
+extends: Packages/ShellScript/Bash.sublime-syntax
+
+contexts:
+  main:
+    - meta_prepend: true
+    - include: ssh-config-none
+
+  expansions-parameter:
+    - meta_prepend: true
+    - include: ssh-config-char-escapes
+
+  string-prototype:
+    - meta_prepend: true
+    - include: ssh-config-char-escapes
+
+  ssh-config-char-escapes:
+    - match: '{{ssh_config_character_escapes}}'
+      scope: constant.character.escape.ssh_config
+
+  ssh-config-none:
+    - match: none
+      scope: constant.language.set.ssh_config
+      pop: true
+    #- include: scope:source.ssh_config#pop-nl-as-value
+
+variables:
+  # requires Packages PR #4024
+  # lazy escaping from heredoc as shell maybe indented
+  no_indent: ^\s*
+  tab_indent: ^\s*
+  ssh_config_character_escapes: '%[%hpr]'

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If these commands open the wrong file for you, open the Command Palette
 - Open the project from under `Packages/SSH Config`
 - Open a syntax test file located in the Tests directory
 - Run `Build With: Syntax Tests` command
-    + supplied by the `PackageDev` Sublime Package
+    + supplied by the `Default` Sublime Package
     + available on the command palette when a test file is open
 
 ## To-Do

--- a/SSH Common.sublime-syntax
+++ b/SSH Common.sublime-syntax
@@ -46,7 +46,9 @@ contexts:
         1: comment.line.number-sign.ssh.common punctuation.definition.comment.ssh.common
       push:
         - meta_content_scope: comment.line.number-sign.ssh.common
-        - include: pop-nl
+        - match: \n
+          scope: comment.line.number-sign.ssh.common
+          pop: true
 
   comments-semicolon:
     - match: ^\s*(;)

--- a/SSH Config.sublime-syntax
+++ b/SSH Config.sublime-syntax
@@ -7,6 +7,10 @@ name: SSH Config
 file_extensions:
   - ssh_config
 scope: source.ssh_config
+
+variables:
+  pop_before_match_option: (?=$|[ \t]*(?i:all|canonical|exec|host|originalhost|user|localuser)\b)
+
 contexts:
   main:
     - include: comments
@@ -31,7 +35,7 @@ contexts:
 
   pop-before-match-option:
     - include: SSH Common.sublime-syntax#pop-before-nl
-    - match: (?=[ \t]*(?i:all|canonical|exec|host|originalhost|user|localuser)\b)
+    - match: '{{pop_before_match_option}}'
       pop: true
 
   pop-before-next-host:
@@ -49,7 +53,6 @@ contexts:
         - meta_scope: meta.block.naked.ssh_config
         - include: pop-before-next-host
         - include: options
-
   # Host
   host:
     - match: ^[ \t]*((?i:host))\b
@@ -98,12 +101,12 @@ contexts:
     - match: \b((?i:exec))\b[ \t]+
       captures:
         1: keyword.other.ssh_config
-      with_prototype:
-        - include: match-exec-tokens
-        - include: pop-before-match-option
-      push:
-        - meta_content_scope: source.embedded.shell
-        - include: scope:source.shell
+      # with_prototype:
+      #   - include: match-exec-tokens
+      #   - include: pop-before-match-option
+      embed: scope:source.shell.bash.ssh_config
+      embed_scope: source.embedded.shell
+      escape: '{{pop_before_match_option}}'
 
     - match: \b(?i:(?:original)?host)\b
       scope: keyword.other.ssh_config
@@ -175,36 +178,29 @@ contexts:
       captures:
         1: meta.mapping.key.ssh_config keyword.other.ssh_config
         2: keyword.operator.assignment.ssh_config
-      with_prototype:
-        - match: '%[%hpr]'
-          scope: constant.character.escape.ssh_config
-      push:
-        - meta_content_scope: meta.mapping.value.ssh_config source.embedded.shell
-        - match: none
-          scope: constant.language.set.ssh_config
-          pop: true
-        - include: scope:source.shell
-        - include: pop-nl-as-value
+      embed: scope:source.shell.bash.ssh_config
+      embed_scope: meta.mapping.value.ssh_config source.embedded.shell
+      escape: $
 
   localcommand:
     - match: ^\s*((?i:localcommand))\b[ \t]*(=)?
       captures:
         1: meta.mapping.key.ssh_config keyword.other.ssh_config
         2: keyword.operator.assignment.ssh_config
-      with_prototype:
-        - match: '%[%CdhilnprTu]'
-          scope: constant.character.escape.ssh_config
-      push:
-        - meta_content_scope: meta.mapping.value.ssh_config source.embedded.shell
-        - match: none
-          scope: constant.language.set.ssh_config
-          pop: true
-        - include: scope:source.shell
-        - include: pop-nl-as-value
+      # with_prototype:
+      #   - match: '%[%CdhilnprTu]'
+      #     scope: constant.character.escape.ssh_config
+      embed: scope:source.shell.bash.ssh_config
+      embed_scope: meta.mapping.value.ssh_config source.embedded.shell
+      escape: \n
+      escape_captures:
+        0: meta.mapping.value.ssh_config
 
   boolean-value:
-    - match: \b(?i:yes|no)\b
-      scope: constant.language.boolean.ssh_config
+    - match: \b(?i:yes)\b
+      scope: constant.language.boolean.true.ssh_config
+    - match: \b(?i:no)\b
+      scope: constant.language.boolean.false.ssh_config
 
   boolean-value-with-typing:
     - include: boolean-value

--- a/SSHD Config.sublime-syntax
+++ b/SSHD Config.sublime-syntax
@@ -136,13 +136,11 @@ contexts:
       captures:
         1: meta.mapping.key.sshd_config keyword.other.sshd_config
         2: keyword.operator.assignment.sshd_config
-      push:
-        - meta_content_scope: meta.mapping.value.sshd_config source.embedded.shell
-        - match: none
-          scope: constant.language.set.sshd_config
-          pop: true
-        - include: scope:source.shell
-        - include: pop-nl-as-value
+      embed: scope:source.shell.bash.ssh_config
+      embed_scope: meta.mapping.value.ssh_config source.embedded.shell
+      escape: \n
+      escape_captures:
+        0: meta.mapping.value.ssh_config
 
   generic-option:
     - match: ^\s*([a-zA-Z1]+)\b[ \t]*(=)?

--- a/Tests/syntax_test_client.ssh_config
+++ b/Tests/syntax_test_client.ssh_config
@@ -31,7 +31,7 @@ Match Host targ?t_host Exec not_inside_network User sue
 #                                                   ^^^ string.unquoted
     ProxyCommand ssh -W %h:%p proxy_server
 #<- - meta.statement
-    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.match
+    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.match
     # ^^^^^^^^^^                             keyword.other
     #            ^^^^^^^^^^^^^^^^^^^^^^^^^   source.embedded.shell
     #                   ^^                   constant.character.escape
@@ -99,12 +99,12 @@ Host *.splat?.com
 
 # Comment
 # <- comment.line.number-sign punctuation.definition.comment
-#^^^^^^^^ comment.line.number-sign
+#^^^^^^^^^ comment.line.number-sign
 
     # Comment
 #^^^ - comment
     # <- comment.line.number-sign punctuation.definition.comment
-    #^^^^^^^^ comment.line.number-sign
+    #^^^^^^^^^ comment.line.number-sign
 
 Host *
 # ^^              keyword.declaration.host-alias

--- a/Tests/syntax_test_client.ssh_config
+++ b/Tests/syntax_test_client.ssh_config
@@ -49,6 +49,10 @@ Match Host one,two
     User bar
     Port 22
     #    ^^ constant.numeric
+    ProxyCommand none
+#^^^^^^^^^^^^^^^^^^^^ meta.block.match
+#   ^^^^^^^^^^^^ meta.mapping.key keyword.other
+#                ^^^^ meta.mapping.value constant.language.set
 
 Host tj
     User 2022sratna
@@ -118,5 +122,13 @@ Host *
     #                                        ^ punctuation.definition.string.end
     UseKeychain yes
     # ^^^^^^^^^     keyword.other
-    #           ^^^ constant.language.boolean
+    #           ^^^ constant.language.boolean.true
     UseRoaming no
+#^^^^^^^^^^^^^^^^ meta.block.host
+#^^^ - meta.mapping
+#   ^^^^^^^^^^ meta.mapping.key keyword.other
+#              ^^ meta.mapping.value constant.language.boolean.false
+    LogLevel Quiet
+#^^^^^^^^^^^^^^^^^ meta.block.host
+#   ^^^^^^^^ meta.mapping.key keyword.other
+#            ^^^^^ meta.mapping.value string.unquoted


### PR DESCRIPTION
Avoid `with_prototype` to fix context recursion sanity limit with latest ShellScript syntax from sublimehq/Packages master branch