### PR TITLE
Generate tests for SSHD indexing

### DIFF
--- a/SSHD Config.sublime-syntax
+++ b/SSHD Config.sublime-syntax
@@ -309,8 +309,8 @@ variables:
                   | PenaltyExemptList )
       | PidFile | Port | PrintLastLog | PrintMotd | Protocol
       | Pubkey (?: AcceptedAlgorithms | AcceptedKeyTypes | AuthOptions
-               | PubkeyAuthentication )
-      | RekeyLimit | RequiredRSASize | RevokedKeys | RDomain
+               | Authentication )
+      | RefuseConnection | RekeyLimit | RequiredRSASize | RevokedKeys | RDomain
       | RhostsRSAAuthentication | RSAAuthentication
       | SecurityKeyProvider | ServerKeyBits | SetEnv | ShowPatchLevel
       # SshdAuthPath and SshSessionPath are just for tests

--- a/Tests/syntax_test_server_index.sshd_config
+++ b/Tests/syntax_test_server_index.sshd_config
@@ -1,0 +1,559 @@
+# SYNTAX TEST "Packages/SSH Config/SSHD Config.sublime-syntax"
+
+ AcceptEnv no
+#@@@@@@@@@ local-definition
+#AcceptEnv no
+#@@@@@@@@@ local-definition
+
+ AddressFamily no
+#@@@@@@@@@@@@@ local-definition
+#AddressFamily no
+#@@@@@@@@@@@@@ local-definition
+
+ AllowAgentForwarding no
+#@@@@@@@@@@@@@@@@@@@@ local-definition
+#AllowAgentForwarding no
+#@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ AllowGroups no
+#@@@@@@@@@@@ local-definition
+#AllowGroups no
+#@@@@@@@@@@@ local-definition
+
+ AllowStreamLocalForwarding no
+#@@@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+#AllowStreamLocalForwarding no
+#@@@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ AllowTcpForwarding no
+#@@@@@@@@@@@@@@@@@@ local-definition
+#AllowTcpForwarding no
+#@@@@@@@@@@@@@@@@@@ local-definition
+
+ AllowUsers no
+#@@@@@@@@@@ local-definition
+#AllowUsers no
+#@@@@@@@@@@ local-definition
+
+ AuthenticationMethods no
+#@@@@@@@@@@@@@@@@@@@@@ local-definition
+#AuthenticationMethods no
+#@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ AuthorizedKeysCommand no
+#@@@@@@@@@@@@@@@@@@@@@ local-definition
+#                      @@ reference
+#AuthorizedKeysCommand no
+#@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ AuthorizedKeysCommandUser no
+#@@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+#AuthorizedKeysCommandUser no
+#@@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ AuthorizedKeysFile no
+#@@@@@@@@@@@@@@@@@@ local-definition
+#AuthorizedKeysFile no
+#@@@@@@@@@@@@@@@@@@ local-definition
+
+ AuthorizedPrincipalsCommand no
+#@@@@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+#                            @@ reference
+#AuthorizedPrincipalsCommand no
+#@@@@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ AuthorizedPrincipalsCommandUser no
+#@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+#AuthorizedPrincipalsCommandUser no
+#@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ AuthorizedPrincipalsFile no
+#@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+#AuthorizedPrincipalsFile no
+#@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ Banner no
+#@@@@@@ local-definition
+#Banner no
+#@@@@@@ local-definition
+
+ CASignatureAlgorithms no
+#@@@@@@@@@@@@@@@@@@@@@ local-definition
+#CASignatureAlgorithms no
+#@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ ChallengeResponseAuthentication no
+#@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+#ChallengeResponseAuthentication no
+#@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ ChannelTimeout no
+#@@@@@@@@@@@@@@ local-definition
+#ChannelTimeout no
+#@@@@@@@@@@@@@@ local-definition
+
+ ChrootDirectory no
+#@@@@@@@@@@@@@@@ local-definition
+#ChrootDirectory no
+#@@@@@@@@@@@@@@@ local-definition
+
+ Ciphers no
+#@@@@@@@ local-definition
+#Ciphers no
+#@@@@@@@ local-definition
+
+ ClientAliveCountMax no
+#@@@@@@@@@@@@@@@@@@@ local-definition
+#ClientAliveCountMax no
+#@@@@@@@@@@@@@@@@@@@ local-definition
+
+ ClientAliveInterval no
+#@@@@@@@@@@@@@@@@@@@ local-definition
+#ClientAliveInterval no
+#@@@@@@@@@@@@@@@@@@@ local-definition
+
+ Compression no
+#@@@@@@@@@@@ local-definition
+#Compression no
+#@@@@@@@@@@@ local-definition
+
+ DenyGroups no
+#@@@@@@@@@@ local-definition
+#DenyGroups no
+#@@@@@@@@@@ local-definition
+
+ DenyUsers no
+#@@@@@@@@@ local-definition
+#DenyUsers no
+#@@@@@@@@@ local-definition
+
+ DisableForwarding no
+#@@@@@@@@@@@@@@@@@ local-definition
+#DisableForwarding no
+#@@@@@@@@@@@@@@@@@ local-definition
+
+ ExposeAuthInfo no
+#@@@@@@@@@@@@@@ local-definition
+#ExposeAuthInfo no
+#@@@@@@@@@@@@@@ local-definition
+
+ FingerprintHash no
+#@@@@@@@@@@@@@@@ local-definition
+#FingerprintHash no
+#@@@@@@@@@@@@@@@ local-definition
+
+ ForceCommand no
+#@@@@@@@@@@@@ local-definition
+#             @@ reference
+#ForceCommand no
+#@@@@@@@@@@@@ local-definition
+
+ GatewayPorts no
+#@@@@@@@@@@@@ local-definition
+#GatewayPorts no
+#@@@@@@@@@@@@ local-definition
+
+ GSSAPIAuthentication no
+#@@@@@@@@@@@@@@@@@@@@ local-definition
+#GSSAPIAuthentication no
+#@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ GSSAPICleanupCredentials no
+#@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+#GSSAPICleanupCredentials no
+#@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ GSSAPIStrictAcceptorCheck no
+#@@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+#GSSAPIStrictAcceptorCheck no
+#@@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ HostbasedAcceptedAlgorithms no
+#@@@@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+#HostbasedAcceptedAlgorithms no
+#@@@@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ HostbasedAcceptedKeyTypes no
+#@@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+#HostbasedAcceptedKeyTypes no
+#@@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ HostbasedAuthentication no
+#@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+#HostbasedAuthentication no
+#@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ HostbasedUsesNameFromPacketOnly no
+#@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+#HostbasedUsesNameFromPacketOnly no
+#@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ HostCertificate no
+#@@@@@@@@@@@@@@@ local-definition
+#HostCertificate no
+#@@@@@@@@@@@@@@@ local-definition
+
+ HostKey no
+#@@@@@@@ local-definition
+#HostKey no
+#@@@@@@@ local-definition
+
+ HostKeyAgent no
+#@@@@@@@@@@@@ local-definition
+#HostKeyAgent no
+#@@@@@@@@@@@@ local-definition
+
+ HostKeyAlgorithms no
+#@@@@@@@@@@@@@@@@@ local-definition
+#HostKeyAlgorithms no
+#@@@@@@@@@@@@@@@@@ local-definition
+
+ IgnoreRhosts no
+#@@@@@@@@@@@@ local-definition
+#IgnoreRhosts no
+#@@@@@@@@@@@@ local-definition
+
+ IgnoreUserKnownHosts no
+#@@@@@@@@@@@@@@@@@@@@ local-definition
+#IgnoreUserKnownHosts no
+#@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ Include no
+#@@@@@@@ local-definition
+#Include no
+#@@@@@@@ local-definition
+
+ IPQoS no
+#@@@@@ local-definition
+#IPQoS no
+#@@@@@ local-definition
+
+ KbdInteractiveAuthentication no
+#@@@@@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+#KbdInteractiveAuthentication no
+#@@@@@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ KerberosAuthentication no
+#@@@@@@@@@@@@@@@@@@@@@@ local-definition
+#KerberosAuthentication no
+#@@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ KerberosGetAFSToken no
+#@@@@@@@@@@@@@@@@@@@ local-definition
+#KerberosGetAFSToken no
+#@@@@@@@@@@@@@@@@@@@ local-definition
+
+ KerberosOrLocalPasswd no
+#@@@@@@@@@@@@@@@@@@@@@ local-definition
+#KerberosOrLocalPasswd no
+#@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ KerberosTicketCleanup no
+#@@@@@@@@@@@@@@@@@@@@@ local-definition
+#KerberosTicketCleanup no
+#@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ KexAlgorithms no
+#@@@@@@@@@@@@@ local-definition
+#KexAlgorithms no
+#@@@@@@@@@@@@@ local-definition
+
+ KeyRegenerationInterval no
+#@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+#KeyRegenerationInterval no
+#@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ ListenAddress no
+#@@@@@@@@@@@@@ local-definition
+#ListenAddress no
+#@@@@@@@@@@@@@ local-definition
+
+ LoginGraceTime no
+#@@@@@@@@@@@@@@ local-definition
+#LoginGraceTime no
+#@@@@@@@@@@@@@@ local-definition
+
+ LogLevel no
+#@@@@@@@@ local-definition
+#LogLevel no
+#@@@@@@@@ local-definition
+
+ LogVerbose no
+#@@@@@@@@@@ local-definition
+#LogVerbose no
+#@@@@@@@@@@ local-definition
+
+ MACs no
+#@@@@ local-definition
+#MACs no
+#@@@@ local-definition
+
+ MaxAuthTries no
+#@@@@@@@@@@@@ local-definition
+#MaxAuthTries no
+#@@@@@@@@@@@@ local-definition
+
+ MaxSessions no
+#@@@@@@@@@@@ local-definition
+#MaxSessions no
+#@@@@@@@@@@@ local-definition
+
+ MaxStartups no
+#@@@@@@@@@@@ local-definition
+#MaxStartups no
+#@@@@@@@@@@@ local-definition
+
+ ModuliFile no
+#@@@@@@@@@@ local-definition
+#ModuliFile no
+#@@@@@@@@@@ local-definition
+
+ PasswordAuthentication no
+#@@@@@@@@@@@@@@@@@@@@@@ local-definition
+#PasswordAuthentication no
+#@@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ PermitEmptyPasswords no
+#@@@@@@@@@@@@@@@@@@@@ local-definition
+#PermitEmptyPasswords no
+#@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ PermitListen no
+#@@@@@@@@@@@@ local-definition
+#PermitListen no
+#@@@@@@@@@@@@ local-definition
+
+ PermitOpen no
+#@@@@@@@@@@ local-definition
+#PermitOpen no
+#@@@@@@@@@@ local-definition
+
+ PermitRootLogin no
+#@@@@@@@@@@@@@@@ local-definition
+#PermitRootLogin no
+#@@@@@@@@@@@@@@@ local-definition
+
+ PermitTTY no
+#@@@@@@@@@ local-definition
+#PermitTTY no
+#@@@@@@@@@ local-definition
+
+ PermitTunnel no
+#@@@@@@@@@@@@ local-definition
+#PermitTunnel no
+#@@@@@@@@@@@@ local-definition
+
+ PermitUserEnvironment no
+#@@@@@@@@@@@@@@@@@@@@@ local-definition
+#PermitUserEnvironment no
+#@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ PermitUserRC no
+#@@@@@@@@@@@@ local-definition
+#PermitUserRC no
+#@@@@@@@@@@@@ local-definition
+
+ PerSourceMaxStartups no
+#@@@@@@@@@@@@@@@@@@@@ local-definition
+#PerSourceMaxStartups no
+#@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ PerSourceNetBlockSize no
+#@@@@@@@@@@@@@@@@@@@@@ local-definition
+#PerSourceNetBlockSize no
+#@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ PerSourcePenalties no
+#@@@@@@@@@@@@@@@@@@ local-definition
+#PerSourcePenalties no
+#@@@@@@@@@@@@@@@@@@ local-definition
+
+ PerSourcePenaltyExemptList no
+#@@@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+#PerSourcePenaltyExemptList no
+#@@@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ PidFile no
+#@@@@@@@ local-definition
+#PidFile no
+#@@@@@@@ local-definition
+
+ Port no
+#@@@@ local-definition
+#Port no
+#@@@@ local-definition
+
+ PrintLastLog no
+#@@@@@@@@@@@@ local-definition
+#PrintLastLog no
+#@@@@@@@@@@@@ local-definition
+
+ PrintMotd no
+#@@@@@@@@@ local-definition
+#PrintMotd no
+#@@@@@@@@@ local-definition
+
+ Protocol no
+#@@@@@@@@ local-definition
+#Protocol no
+#@@@@@@@@ local-definition
+
+ PubkeyAcceptedAlgorithms no
+#@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+#PubkeyAcceptedAlgorithms no
+#@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ PubkeyAcceptedKeyTypes no
+#@@@@@@@@@@@@@@@@@@@@@@ local-definition
+#PubkeyAcceptedKeyTypes no
+#@@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ PubkeyAuthOptions no
+#@@@@@@@@@@@@@@@@@ local-definition
+#PubkeyAuthOptions no
+#@@@@@@@@@@@@@@@@@ local-definition
+
+ PubkeyAuthentication no
+#@@@@@@@@@@@@@@@@@@@@ local-definition
+#PubkeyAuthentication no
+#@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ RefuseConnection no
+#@@@@@@@@@@@@@@@@ local-definition
+#RefuseConnection no
+#@@@@@@@@@@@@@@@@ local-definition
+
+ RekeyLimit no
+#@@@@@@@@@@ local-definition
+#RekeyLimit no
+#@@@@@@@@@@ local-definition
+
+ RequiredRSASize no
+#@@@@@@@@@@@@@@@ local-definition
+#RequiredRSASize no
+#@@@@@@@@@@@@@@@ local-definition
+
+ RevokedKeys no
+#@@@@@@@@@@@ local-definition
+#RevokedKeys no
+#@@@@@@@@@@@ local-definition
+
+ RDomain no
+#@@@@@@@ local-definition
+#RDomain no
+#@@@@@@@ local-definition
+
+ RhostsRSAAuthentication no
+#@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+#RhostsRSAAuthentication no
+#@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ RSAAuthentication no
+#@@@@@@@@@@@@@@@@@ local-definition
+#RSAAuthentication no
+#@@@@@@@@@@@@@@@@@ local-definition
+
+ SecurityKeyProvider no
+#@@@@@@@@@@@@@@@@@@@ local-definition
+#SecurityKeyProvider no
+#@@@@@@@@@@@@@@@@@@@ local-definition
+
+ ServerKeyBits no
+#@@@@@@@@@@@@@ local-definition
+#ServerKeyBits no
+#@@@@@@@@@@@@@ local-definition
+
+ SetEnv no
+#@@@@@@ local-definition
+#SetEnv no
+#@@@@@@ local-definition
+
+ ShowPatchLevel no
+#@@@@@@@@@@@@@@ local-definition
+#ShowPatchLevel no
+#@@@@@@@@@@@@@@ local-definition
+
+ StreamLocalBindMask no
+#@@@@@@@@@@@@@@@@@@@ local-definition
+#StreamLocalBindMask no
+#@@@@@@@@@@@@@@@@@@@ local-definition
+
+ StreamLocalBindUnlink no
+#@@@@@@@@@@@@@@@@@@@@@ local-definition
+#StreamLocalBindUnlink no
+#@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ StrictModes no
+#@@@@@@@@@@@ local-definition
+#StrictModes no
+#@@@@@@@@@@@ local-definition
+
+ Subsystem no
+#@@@@@@@@@ local-definition
+#Subsystem no
+#@@@@@@@@@ local-definition
+
+ SyslogFacility no
+#@@@@@@@@@@@@@@ local-definition
+#SyslogFacility no
+#@@@@@@@@@@@@@@ local-definition
+
+ TCPKeepAlive no
+#@@@@@@@@@@@@ local-definition
+#TCPKeepAlive no
+#@@@@@@@@@@@@ local-definition
+
+ TrustedUserCAKeys no
+#@@@@@@@@@@@@@@@@@ local-definition
+#TrustedUserCAKeys no
+#@@@@@@@@@@@@@@@@@ local-definition
+
+ UnusedConnectionTimeout no
+#@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+#UnusedConnectionTimeout no
+#@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ UseDNS no
+#@@@@@@ local-definition
+#UseDNS no
+#@@@@@@ local-definition
+
+ UseLogin no
+#@@@@@@@@ local-definition
+#UseLogin no
+#@@@@@@@@ local-definition
+
+ UsePAM no
+#@@@@@@ local-definition
+#UsePAM no
+#@@@@@@ local-definition
+
+ UsePrivilegeSeparation no
+#@@@@@@@@@@@@@@@@@@@@@@ local-definition
+#UsePrivilegeSeparation no
+#@@@@@@@@@@@@@@@@@@@@@@ local-definition
+
+ VersionAddendum no
+#@@@@@@@@@@@@@@@ local-definition
+#VersionAddendum no
+#@@@@@@@@@@@@@@@ local-definition
+
+ X11DisplayOffset no
+#@@@@@@@@@@@@@@@@ local-definition
+#X11DisplayOffset no
+#@@@@@@@@@@@@@@@@ local-definition
+
+ X11Forwarding no
+#@@@@@@@@@@@@@ local-definition
+#X11Forwarding no
+#@@@@@@@@@@@@@ local-definition
+
+ X11UseLocalhost no
+#@@@@@@@@@@@@@@@ local-definition
+#X11UseLocalhost no
+#@@@@@@@@@@@@@@@ local-definition
+
+ XAuthLocation no
+#@@@@@@@@@@@@@ local-definition
+#XAuthLocation no
+#@@@@@@@@@@@@@ local-definition

--- a/src/build.py
+++ b/src/build.py
@@ -17,7 +17,7 @@ def build_ssh_options():
             stream, Loader=yaml.BaseLoader)
 
     for domain, settings in ssh_options_input.items():
-        completions: CompletionItem = {
+        completions = {
             'scope': settings['completions']['scope'],
             'completions': [],
         }
@@ -37,12 +37,12 @@ def build_ssh_options():
             if not options or 'values' not in options:
                 continue
 
-            values = options['values']
+            values: str | list[str] = options['values']
             if isinstance(values, (str)):
                 value_string = values
             else:
                 value_string = f'${{0:{{ {" | ".join(values)} \\}}}}'
-            completions['completions'].append({
+            _ = completions['completions'].append({
                 'trigger': keyword.lower(),
                 'contents': f'{keyword}{snippet_spacer}{value_string}',
                 # 'annotation': annotation,
@@ -78,7 +78,7 @@ def build_sshd_index_test():
             f'#{"@" * len(item)} local-definition\n')
 
     with open('../Tests/syntax_test_server_index.sshd_config', 'w') as test_file:
-        test_file.write('\n'.join(test_content))
+        _ = test_file.write('\n'.join(test_content))
 
 
 def build_crypto():
@@ -166,11 +166,11 @@ def build_crypto():
             json.dump(completions, f, indent=4)
 
     with open('../SSH Crypto.sublime-syntax', 'w') as syntax_file:
-        syntax_file.write('%YAML 1.2\n---\n')
+        _ = syntax_file.write('%YAML 1.2\n---\n')
         yaml.dump(syntax_content, syntax_file)
 
     with open('../Tests/syntax_test_crypto', 'w') as test_file:
-        test_file.write('\n'.join(test_content))
+        _ = test_file.write('\n'.join(test_content))
 
 
 def main():

--- a/src/build.py
+++ b/src/build.py
@@ -1,26 +1,33 @@
 #!/usr/bin/env python
 
+from __future__ import annotations
 import json
 import re
 import yaml
 
+CompletionItem: dict[str, str | list[str]]
+CompletionMetadata: dict[str, str | list[str]]
+CompletionSet: dict[str, CompletionItem | CompletionMetadata]
+CryptoSet: dict[str, str | list[str]]
+
 
 def build_ssh_options():
     with open('options.yaml', 'r') as stream:
-        ssh_options_input = yaml.load(stream, Loader=yaml.BaseLoader)
+        ssh_options_input: dict[str, CompletionSet] = yaml.load(
+            stream, Loader=yaml.BaseLoader)
 
     for domain, settings in ssh_options_input.items():
-        completions = {
+        completions: CompletionItem = {
             'scope': settings['completions']['scope'],
             'completions': [],
         }
-        snippet_spacer = settings['completions'].get('snippet_spacer', ' ')
-        default_kind = settings['completions']['kind']
-        annotation = settings['completions']['annotation']
+        snippet_spacer: str = settings['completions'].get('snippet_spacer', ' ')
+        default_kind: list[str] = settings['completions']['kind']
+        annotation: str = settings['completions']['annotation']
 
         for keyword, options in settings['items'].items():
-            details = options.get('details', '') if options else ''
-            completions['completions'].append({
+            details: str = options.get('details', '') if options else ''
+            _ = completions['completions'].append({
                 'trigger': keyword,
                 'contents': keyword,
                 # 'annotation': annotation,
@@ -102,13 +109,13 @@ def build_crypto():
             'scope': settings['completions']['scope'].strip(),
             'completions': [],
         }
-        default_kind = settings['completions']['kind']
-        annotation = settings['completions']['annotation']
-        active_scope = settings['active']['scope']
-        deprec_scope = settings['deprecated']['scope']
+        default_kind: list[str] = settings['completions']['kind']
+        annotation: str = settings['completions']['annotation']
+        active_scope: str = settings['active']['scope']
+        deprec_scope: str = settings['deprecated']['scope']
 
         test_content.append(f'\n###[ {domain + " ]":#<74}\n')
-        syntax_content['contexts']['main'].append({
+        _ = syntax_content['contexts']['main'].append({
             'match': fr'^{annotation}:',
             'push': [
                 {'include': 'pop-before-nl'},
@@ -133,7 +140,7 @@ def build_crypto():
         ]
 
         for item in settings['active']['items']:
-            completions['completions'].append({
+            _ = completions['completions'].append({
                 'trigger': f'{item}\t{annotation}',
                 'contents': item,
                 'annotation': annotation,
@@ -144,7 +151,7 @@ def build_crypto():
                 f'#{" " * len(annotation)} {"^" * len(item)} {active_scope}')
 
         for item in settings['deprecated']['items']:
-            completions['completions'].append({
+            _ = completions['completions'].append({
                 'trigger': f'{item}\tdeprecated {annotation}',
                 'contents': item,
                 'annotation': f'deprecated {annotation}',

--- a/src/build.py
+++ b/src/build.py
@@ -47,6 +47,33 @@ def build_ssh_options():
             json.dump(completions, f, indent=4)
 
 
+def build_sshd_index_test():
+    with open('options.yaml', 'r') as stream:
+        ssh_options_input: dict[str, CompletionSet] = yaml.load(
+            stream, Loader=yaml.BaseLoader)
+
+    test_content = [
+        '# SYNTAX TEST "Packages/SSH Config/SSHD Config.sublime-syntax"\n',
+    ]
+
+    for item in ssh_options_input['SSHD Config']['items']:
+        if item in {'Match'}:
+            continue
+
+        test_content.append(f' {item} no')
+        test_content.append(
+            f'#{"@" * len(item)} local-definition')
+        if item.endswith('Command'):
+            test_content.append(
+                f'#{" " * len(item)} @@ reference')
+        test_content.append(f'#{item} no')
+        test_content.append(
+            f'#{"@" * len(item)} local-definition\n')
+
+    with open('../Tests/syntax_test_server_index.sshd_config', 'w') as test_file:
+        test_file.write('\n'.join(test_content))
+
+
 def build_crypto():
     with open('crypto.yaml', 'r') as stream:
         crypto_input = yaml.load(stream, Loader=yaml.BaseLoader)
@@ -141,6 +168,7 @@ def build_crypto():
 
 def main():
     build_ssh_options()
+    build_sshd_index_test()
     build_crypto()
 
 


### PR DESCRIPTION
This PR guarantees that all parameters in the SSHD `options.yaml` are available in the local definitions list whether they are commented or active.

It actually uncovered two missing ones.