### PR TITLE
Move PEM first line to a variable

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -28,8 +28,8 @@ jobs:
             packages: master
           - build: 'stable'
             packages: binary
-          - build: 4185  # Required for symbol transformation tests
-            packages: v4193  # Bash rewrite
+          - build: 4194  # Required for variables in first_line_match
+            packages: binary
     steps:
       - uses: actions/checkout@v6
       - uses: SublimeText/syntax-test-action@v2

--- a/syntax/PEM.sublime-syntax
+++ b/syntax/PEM.sublime-syntax
@@ -29,44 +29,12 @@ hidden_file_extensions:
   - ssh_host_ed25519_key
   - ssh_host_rsa_key
 
-first_line_match: |-
-        ^(?x:
-          (-{4}[ -])
-          BEGIN [ ]
-          ( (?:[0-9A-Z -]+[ ])? (?: PUBLIC | PRIVATE ) [ ] KEY
-          | (?:[0-9A-Z -]+[ ])? CERTIFICATE (?:[ ] REQUEST )?
-          | (?:[0-9A-Z -]+[ ])? PARAMETERS
-          | X509 [ ] CRL
-          | PKCS7
-          | PKCS [ ] \#7 [ ] SIGNED [ ] DATA
-          | CMS
-          | PGP [ ] MESSAGE (?:,[ ] PART [ ] \d+(?:/\d+)?)?
-          | PGP [ ] (?: PUBLIC | PRIVATE ) [ ] KEY [ ] BLOCK
-          | PGP [ ] SIGNATURE
-          )
-          ([ -]-{4})
-        )
+first_line_match: '{{first_line_match}}'
 
 contexts:
   main:
     - include: comments-number-sign
-    - match: |-
-        ^(?x:
-          (-{4}[ -])
-          BEGIN [ ]
-          ( (?:[0-9A-Z -]+[ ])? (?: PUBLIC | PRIVATE ) [ ] KEY
-          | (?:[0-9A-Z -]+[ ])? CERTIFICATE (?:[ ] REQUEST )?
-          | (?:[0-9A-Z -]+[ ])? PARAMETERS
-          | X509 [ ] CRL
-          | PKCS7
-          | PKCS [ ] \#7 [ ] SIGNED [ ] DATA
-          | CMS
-          | PGP [ ] MESSAGE (?:,[ ] PART [ ] \d+(?:/\d+)?)?
-          | PGP [ ] (?: PUBLIC | PRIVATE ) [ ] KEY [ ] BLOCK
-          | PGP [ ] SIGNATURE
-          )
-          ([ -]-{4})
-        )
+    - match: '{{first_line_match}}'
       scope: punctuation.section.block.begin.pem
       push: pem-key
     - include: setext-headings
@@ -159,3 +127,24 @@ contexts:
   not-heading:
     - match: ''
       pop: 1
+
+###############################################################################
+
+variables:
+  first_line_match: |-
+    ^(?x:
+      (-{4}[ -])
+      BEGIN [ ]
+      ( (?:[0-9A-Z -]+[ ])? (?: PUBLIC | PRIVATE ) [ ] KEY
+      | (?:[0-9A-Z -]+[ ])? CERTIFICATE (?:[ ] REQUEST )?
+      | (?:[0-9A-Z -]+[ ])? PARAMETERS
+      | X509 [ ] CRL
+      | PKCS7
+      | PKCS [ ] \#7 [ ] SIGNED [ ] DATA
+      | CMS
+      | PGP [ ] MESSAGE (?:,[ ] PART [ ] \d+(?:/\d+)?)?
+      | PGP [ ] (?: PUBLIC | PRIVATE ) [ ] KEY [ ] BLOCK
+      | PGP [ ] SIGNATURE
+      )
+      ([ -]-{4})
+    )


### PR DESCRIPTION
This works great, but requires a new tag series on Package Control Channel. It's not really worth minting a tag series for such a minimal change, but let's keep it in mind if there are other more-impactful features that need a new ST version.