### PR TITLE
Fix accepted values for `ControlMaster` and `StrictHostKeyChecking`

### DIFF
--- a/src/options.yaml
+++ b/src/options.yaml
@@ -149,6 +149,8 @@
         - 'yes'
         - 'no'
         - ask
+        - auto
+        - autoask
     ControlPath:
       details: Tokenized path to connection sharing file
       values: ${0:~/.ssh/control-%h-%p-%r}

--- a/support/generated/SSH Config.sublime-completions
+++ b/support/generated/SSH Config.sublime-completions
@@ -304,7 +304,7 @@
         },
         {
             "trigger": "controlmaster",
-            "contents": "ControlMaster ${0:{ yes | no | ask \\}}",
+            "contents": "ControlMaster ${0:{ yes | no | ask | auto | autoask \\}}",
             "annotation": "option",
             "kind": "snippet",
             "details": "Set connection sharing for multiple sessions on <code>ControlPath</code>"

--- a/syntax/SSH Config.sublime-syntax
+++ b/syntax/SSH Config.sublime-syntax
@@ -28,6 +28,7 @@ contexts:
     - include: parameter-with-boolean-values
     - include: parameter-with-boolean-values-plus-ask
     - include: parameter-controlmaster
+    - include: parameter-stricthostkeychecking
     - include: parameter-generic
 
   tokens:
@@ -352,9 +353,7 @@ contexts:
     - match: |-
         (?xi:
           ^\s*
-          ( StrictHostKeyChecking | UpdateHostKeys
-          | VerifyHostKeyDNS
-          )
+          ( UpdateHostKeys | VerifyHostKeyDNS )
           \b[ \t]*(=)?
         )
       captures:
@@ -386,6 +385,29 @@ contexts:
           scope: constant.language.ssh_config
         # Consume "ask"/"auto"/"autoask" while typing as well, but unscoped
         - match: \b(?:as?|aut?|autoas?)\b
+        - match: '[^"\s]+'
+          scope: invalid.illegal.sshd_config
+      push: possibly-quoted-value
+
+  parameter-stricthostkeychecking:
+    - match: |-
+        (?xi:
+          ^\s*
+          ( StrictHostKeyChecking )
+          \b[ \t]*(=)?
+        )
+      captures:
+        1: meta.mapping.key.ssh_config keyword.other.ssh_config
+        2: keyword.operator.assignment.ssh_config
+      with_prototype:
+        - include: boolean-with-typing
+        - include: ask
+        - match: \baccept-new\b
+          scope: constant.language.ssh_config
+        - match: \boff\b
+          scope: constant.language.boolean.false.ssh.common
+        # Consume "ask"/"accept-new"/"off" while typing as well, but unscoped
+        - match: \b(?:as?|ac{1,2}e?p?t?(?:-n?e?)?|of?)\b
         - match: '[^"\s]+'
           scope: invalid.illegal.sshd_config
       push: possibly-quoted-value

--- a/syntax/SSH Config.sublime-syntax
+++ b/syntax/SSH Config.sublime-syntax
@@ -27,6 +27,7 @@ contexts:
     - include: parameter-knownhostscommand
     - include: parameter-with-boolean-values
     - include: parameter-with-boolean-values-plus-ask
+    - include: parameter-controlmaster
     - include: parameter-generic
 
   tokens:
@@ -351,7 +352,7 @@ contexts:
     - match: |-
         (?xi:
           ^\s*
-          ( ControlMaster | StrictHostKeyChecking | UpdateHostKeys
+          ( StrictHostKeyChecking | UpdateHostKeys
           | VerifyHostKeyDNS
           )
           \b[ \t]*(=)?
@@ -364,6 +365,27 @@ contexts:
         - include: ask
         # Consume "ask" while typing as well, but unscoped
         - match: \bas?\b
+        - match: '[^"\s]+'
+          scope: invalid.illegal.sshd_config
+      push: possibly-quoted-value
+
+  parameter-controlmaster:
+    - match: |-
+        (?xi:
+          ^\s*
+          ( ControlMaster )
+          \b[ \t]*(=)?
+        )
+      captures:
+        1: meta.mapping.key.ssh_config keyword.other.ssh_config
+        2: keyword.operator.assignment.ssh_config
+      with_prototype:
+        - include: boolean-with-typing
+        - include: ask
+        - match: \bauto(?:ask)?\b
+          scope: constant.language.ssh_config
+        # Consume "ask"/"auto"/"autoask" while typing as well, but unscoped
+        - match: \b(?:as?|aut?|autoas?)\b
         - match: '[^"\s]+'
           scope: invalid.illegal.sshd_config
       push: possibly-quoted-value

--- a/test/syntax_test_client.ssh_config
+++ b/test/syntax_test_client.ssh_config
@@ -280,6 +280,22 @@ Host *
 #^^^^^^^^^^^^^^^^^^^^^^^ meta.block.host.ssh_config
 #   ^^^^^^^^^^^^^ meta.mapping.key.ssh_config keyword.other.ssh_config
 #                 ^^^^^^ meta.mapping.value.ssh.common invalid.illegal.sshd_config
+    StrictHostKeyChecking accept-new
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.host.ssh_config
+#   ^^^^^^^^^^^^^^^^^^^^^ meta.mapping.key.ssh_config keyword.other.ssh_config
+#                         ^^^^^^^^^^ meta.mapping.value.ssh.common constant.language.ssh_config
+    StrictHostKeyChecking off
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.host.ssh_config
+#   ^^^^^^^^^^^^^^^^^^^^^ meta.mapping.key.ssh_config keyword.other.ssh_config
+#                         ^^^ meta.mapping.value.ssh.common constant.language.boolean.false.ssh.common
+    StrictHostKeyChecking accept-ne
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.host.ssh_config
+#   ^^^^^^^^^^^^^^^^^^^^^ meta.mapping.key.ssh_config keyword.other.ssh_config
+#                         ^^^^^^^^^ meta.mapping.value.ssh.common - invalid - constant
+    StrictHostKeyChecking maybe
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.host.ssh_config
+#   ^^^^^^^^^^^^^^^^^^^^^ meta.mapping.key.ssh_config keyword.other.ssh_config
+#                         ^^^^^ meta.mapping.value.ssh.common invalid.illegal.sshd_config
 
 Match Host *.example.com Exec "! grep -q -E '^\s*search[ \t]+example\.com' /etc/resolv.conf"
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.match.ssh_config

--- a/test/syntax_test_client.ssh_config
+++ b/test/syntax_test_client.ssh_config
@@ -256,6 +256,30 @@ Host *
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.host.ssh_config
 #   ^^^^^^^^^^^^^^^^^^^^^ meta.mapping.key.ssh_config keyword.other.ssh_config
 #                         ^^ meta.mapping.value.ssh.common - invalid - constant
+    ControlMaster yes
+#^^^^^^^^^^^^^^^^^^^^ meta.block.host.ssh_config
+#   ^^^^^^^^^^^^^ meta.mapping.key.ssh_config keyword.other.ssh_config
+#                 ^^^ meta.mapping.value.ssh.common constant.language.boolean.true.ssh.common
+    ControlMaster ask
+#^^^^^^^^^^^^^^^^^^^^ meta.block.host.ssh_config
+#   ^^^^^^^^^^^^^ meta.mapping.key.ssh_config keyword.other.ssh_config
+#                 ^^^ meta.mapping.value.ssh.common constant.language.ssh_config
+    ControlMaster auto
+#^^^^^^^^^^^^^^^^^^^^^ meta.block.host.ssh_config
+#   ^^^^^^^^^^^^^ meta.mapping.key.ssh_config keyword.other.ssh_config
+#                 ^^^^ meta.mapping.value.ssh.common constant.language.ssh_config
+    ControlMaster autoask
+#^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.host.ssh_config
+#   ^^^^^^^^^^^^^ meta.mapping.key.ssh_config keyword.other.ssh_config
+#                 ^^^^^^^ meta.mapping.value.ssh.common constant.language.ssh_config
+    ControlMaster aut
+#^^^^^^^^^^^^^^^^^^^^ meta.block.host.ssh_config
+#   ^^^^^^^^^^^^^ meta.mapping.key.ssh_config keyword.other.ssh_config
+#                 ^^^ meta.mapping.value.ssh.common - invalid - constant
+    ControlMaster always
+#^^^^^^^^^^^^^^^^^^^^^^^ meta.block.host.ssh_config
+#   ^^^^^^^^^^^^^ meta.mapping.key.ssh_config keyword.other.ssh_config
+#                 ^^^^^^ meta.mapping.value.ssh.common invalid.illegal.sshd_config
 
 Match Host *.example.com Exec "! grep -q -E '^\s*search[ \t]+example\.com' /etc/resolv.conf"
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.match.ssh_config


### PR DESCRIPTION
Both options were routed through `parameter-with-boolean-values-plus-ask`, which
only recognizes `yes | no | ask` and marks every other value
`invalid.illegal.sshd_config`. Per `man ssh_config`, `ControlMaster` also accepts
`auto` and `autoask`, and `StrictHostKeyChecking` also accepts `accept-new` and
`off`.

## Changes

One commit per option; each moves the option out of the shared rule into its own
context, following the existing `parameter-<option>` naming pattern:

- **`ControlMaster`** now accepts `yes | no | ask | auto | autoask`. Completions
  updated via `src/options.yaml` and regenerated with `src/build.py`.
- **`StrictHostKeyChecking`** now accepts `yes | no | ask | accept-new | off`.
  `off` is scoped as a boolean false alongside `no`, matching the man page ("If
  this flag is set to *no* or *off* ..."). No completions change needed: they
  already listed both values, so autocomplete no longer inserts values the
  highlighter flags.
- `UpdateHostKeys` and `VerifyHostKeyDNS` keep the shared rule unchanged.
- Both rules keep the unscoped consume-while-typing matches and the
  `invalid.illegal` catch-all, so typos are still flagged.

## Testing

- New assertions in `test/syntax_test_client.ssh_config` cover the four newly
  accepted values, a mid-typing partial, and an invalid value per option.
- Full suite run locally with the `syntax_tests` binary (build 4200): all test
  files pass, before and after each commit.

## Before / After

Stock package:

<img width="1131" height="738" alt="Bug Report BEFORE fix" src="https://github.com/user-attachments/assets/1b4a2512-81e8-4b5a-81d1-1e4b5a3a0a43" />

With this fix:

<img width="1179" height="738" alt="Bug Report AFTER fix" src="https://github.com/user-attachments/assets/1671f41a-9851-45ce-85ec-f3188f81e3c1" />

---

- Fixes #40
- Fixes #41